### PR TITLE
Fix build warnings

### DIFF
--- a/loon/build.gradle
+++ b/loon/build.gradle
@@ -8,8 +8,12 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 24
+        minSdk 21
         targetSdk 33
+
+        aarMetadata {
+            minCompileSdk = 21
+        }
 
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/loon/consumer-rules.pro
+++ b/loon/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep com.sirenartt.loon.startup.LoonStartupInitializer

--- a/loon/src/main/java/com/sirenartt/loon/core/AccessibilityFinding.kt
+++ b/loon/src/main/java/com/sirenartt/loon/core/AccessibilityFinding.kt
@@ -16,7 +16,7 @@ data class AccessibilityFinding(
                 title = checkResult.getRawTitleMessage(Locale.ENGLISH),
                 description = checkResult.getRawMessage(Locale.ENGLISH),
                 target = getTarget(checkResult.element),
-                severity = checkResult.metadata.toString()
+                severity = checkResult.type.toString()
             )
         }
 

--- a/loon/src/main/java/com/sirenartt/loon/core/Screenshotter.kt
+++ b/loon/src/main/java/com/sirenartt/loon/core/Screenshotter.kt
@@ -6,7 +6,6 @@ import android.graphics.Picture
 import android.graphics.Rect
 import android.os.Build
 import android.view.View
-import com.google.android.libraries.accessibility.utils.log.LogUtils
 
 
 internal class Screenshotter {
@@ -50,6 +49,7 @@ internal class Screenshotter {
             }
         }
 
+        @Suppress("DEPRECATION")
         private fun getScreenshotPreP(view: View): Bitmap {
             // The drawing cache is a cheap, easy and compatible way to generate our screenshot.
             // However, because the cache is capped at a maximum size, this method may not work

--- a/loon/src/main/java/com/sirenartt/loon/reporting/AccessibilityReporter.kt
+++ b/loon/src/main/java/com/sirenartt/loon/reporting/AccessibilityReporter.kt
@@ -15,6 +15,7 @@ class AccessibilityReporter {
     private fun log(finding: AccessibilityFinding) {
         Log.w(AccessibilityLoon.tag, "--- [AccessibilityLoon] Found accessibility problem ---")
         Log.w(AccessibilityLoon.tag, "View: ${finding.target}")
+        Log.w(AccessibilityLoon.tag, "Severity: ${finding.severity}")
         Log.w(AccessibilityLoon.tag, "Problem: ${finding.title}")
         Log.w(AccessibilityLoon.tag, "Description: ${finding.description}")
         Log.w(AccessibilityLoon.tag, "-------------------------------------------------------")

--- a/loon/src/main/java/com/sirenartt/loon/startup/LoonLifecycleCallbacks.kt
+++ b/loon/src/main/java/com/sirenartt/loon/startup/LoonLifecycleCallbacks.kt
@@ -4,10 +4,11 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import com.sirenartt.loon.core.AccessibilityLoon
 import java.lang.ref.WeakReference
 
-class LoonLifecycleCallbacks(): Application.ActivityLifecycleCallbacks {
+class LoonLifecycleCallbacks: Application.ActivityLifecycleCallbacks {
     override fun onActivityCreated(p0: Activity, p1: Bundle?) {}
     override fun onActivityStarted(p0: Activity) {}
     override fun onActivityStopped(p0: Activity) {}
@@ -17,7 +18,7 @@ class LoonLifecycleCallbacks(): Application.ActivityLifecycleCallbacks {
     private var currentActivity: WeakReference<Activity>? = null
 
     init {
-        val handler = Handler()
+        val handler = Handler(Looper.getMainLooper())
 
         handler.postDelayed(object : Runnable {
             override fun run() {

--- a/loon/src/main/java/com/sirenartt/loon/startup/LoonStartupInitializer.kt
+++ b/loon/src/main/java/com/sirenartt/loon/startup/LoonStartupInitializer.kt
@@ -4,8 +4,10 @@ import android.app.Application
 import android.content.Context
 import android.util.Log
 import androidx.startup.Initializer
+import com.google.errorprone.annotations.Keep
 import com.sirenartt.loon.core.AccessibilityLoon
 
+@Keep
 @Suppress("unused")
 class LoonStartupInitializer : Initializer<LoonStartupInitializer> {
 


### PR DESCRIPTION
Fix the following build warnings: 

```
w: file:///home/jitpack/build/loon/src/main/java/com/sirenartt/loon/core/Screenshotter.kt:58:18 'buildDrawingCache(): Unit' is deprecated. Deprecated in Java
w: file:///home/jitpack/build/loon/src/main/java/com/sirenartt/loon/core/Screenshotter.kt:59:31 'getter for drawingCache: Bitmap!' is deprecated. Deprecated in Java
w: file:///home/jitpack/build/loon/src/main/java/com/sirenartt/loon/core/Screenshotter.kt:69:22 'destroyDrawingCache(): Unit' is deprecated. Deprecated in Java
w: file:///home/jitpack/build/loon/src/main/java/com/sirenartt/loon/startup/LoonLifecycleCallbacks.kt:20:23 'constructor Handler()' is deprecated. Deprecated in Java
```